### PR TITLE
Fix minor spelling mistake

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -87,7 +87,7 @@ impl FormatBuilder {
         }
     }
 
-    /// Set writing a newline after ever log record
+    /// Set writing a newline after every log record
     pub fn set_newlines(mut self, enabled: bool) -> Self {
         self.newlines = enabled;
         self


### PR DESCRIPTION
Not much of a contribution I know, but this fixes a minor spelling
mistake in the documentation.