### PR TITLE
Implement use of `emit_serde`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,15 @@ readme = "README.md"
 [lib]
 path = "lib.rs"
 
+[features]
+eserde = ["erased-serde"]
+default = ["eserde"]
+
 [dependencies]
-slog = "2"
+# slog = "2"
+slog = {path = "../slog", features = ["serde"]}
 serde_json = "1"
 serde = "1"
 chrono = "0.4"
+
+erased-serde = {version = "0.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default = ["eserde"]
 
 [dependencies]
 # slog = "2"
-slog = {path = "../slog", features = ["serde"]}
+slog = { git = "https://github.com/Metaswitch/slog", branch = "serde", features = ["serde"]}
 serde_json = "1"
 serde = "1"
 chrono = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default = ["eserde"]
 
 [dependencies]
 # slog = "2"
-slog = { git = "https://github.com/Metaswitch/slog", branch = "serde", features = ["serde"]}
+slog = { git = "https://github.com/slog-rs/slog", branch = "serde", features = ["serde"]}
 serde_json = "1"
 serde = "1"
 chrono = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,9 @@ readme = "README.md"
 path = "lib.rs"
 
 [features]
-eserde = ["erased-serde"]
-default = ["eserde"]
+# Can't use "serde" as a fature name because we already depend on serde below.
+nested-values = ["erased-serde"]
+default = ["nested-values"]
 
 [dependencies]
 # slog = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default = ["nested-values"]
 
 [dependencies]
 # slog = "2"
-slog = { git = "https://github.com/slog-rs/slog", branch = "serde", features = ["serde"]}
+slog = { git = "https://github.com/slog-rs/slog", branch = "master", features = ["serde"]}
 serde_json = "1"
 serde = "1"
 chrono = "0.4"

--- a/lib.rs
+++ b/lib.rs
@@ -152,7 +152,7 @@ impl<S> slog::Serializer for SerdeSerializer<S>
         })
     }
 
-    #[cfg(feature = "eserde")]
+    #[cfg(feature = "nested-values")]
     fn emit_serde(&mut self, key: &str, value: &slog::SerdeValue) -> slog::Result {
         impl_m!(self, key, value.as_serde())
     }

--- a/lib.rs
+++ b/lib.rs
@@ -47,7 +47,7 @@ thread_local! {
 /// Newtype to wrap serde Serializer, so that `Serialize` can be implemented
 /// for it
 struct SerdeSerializer<S: serde::Serializer> {
-    /// Current state of map serializing: `serde::Seriaizer::MapState`
+    /// Current state of map serializing: `serde::Serializer::MapState`
     ser_map: S::SerializeMap,
 }
 
@@ -63,7 +63,7 @@ impl<S: serde::Serializer> SerdeSerializer<S> {
     }
 
     /// Finish serialization, and return the serializer
-    fn end(self) -> std::result::Result<S::Ok, S::Error> {
+    fn end(self) -> result::Result<S::Ok, S::Error> {
         self.ser_map.end()
     }
 }
@@ -150,6 +150,11 @@ impl<S> slog::Serializer for SerdeSerializer<S>
             buf.clear();
             res
         })
+    }
+
+    #[cfg(feature = "eserde")]
+    fn emit_serde(&mut self, key: &str, value: &slog::SerdeValue) -> slog::Result {
+        impl_m!(self, key, value.as_serde())
     }
 }
 // }}}


### PR DESCRIPTION
@dpc As discussed on gitter - this adds your new `emit_serde()` support to the JSON serializer.  I've pulled this into some of my local projects and it works a treat. 

Still to do:
- [ ] Update Cargo.toml to use correct version of base `slog` once https://github.com/slog-rs/slog/pull/152 is accepted