### PR TITLE
Flush the IO writer after each log message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+
+* Option `flush` to enable flushing of the `io::Write` after each record.
+
 ## 2.2.0 - 2017-12-10
 ### Added
 


### PR DESCRIPTION
See #13

<details>
<summary>Example for acceptance testing</summary>

```rust
#[macro_use]
extern crate slog;
extern crate slog_json;

use std::sync::Mutex;
use slog::Drain;
use std::io;

struct MyWriter {}

impl io::Write for MyWriter {
    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
        println!("Write: {}", String::from_utf8_lossy(buf));
        Ok(buf.len())
    }
    fn flush(&mut self) -> io::Result<()> {
        println!("Flush!");
        Ok(())
    }
}

fn main() {
    let writer = MyWriter {};
    let drain = slog_json::Json::new(writer)
        .set_flush(true)
        .build();
    let logger = slog::Logger::root(Mutex::new(drain).map(slog::Fuse), o!());

    for i in 1..3 {
        info!(logger, "Hello {}", i; "foo" => "12");
    }
}
```
</details>