### PR TITLE
Replace chrono with time 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ default = []
 slog = { version = "2.1.1" }
 serde_json = "1"
 serde = "1"
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
 erased-serde = {version = "0.3", optional = true }
+time = { version = "0.3.6", features = ["formatting", "local-offset"] }
 
 [dev-dependencies]
 slog-async = "2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,8 +331,11 @@ where
     /// * `msg` - msg - formatted logging message
     pub fn add_default_keys(self) -> Self {
         self.add_key_value(o!(
-            "ts" => PushFnValue(move |_ : &Record, ser| {
-                ser.emit(chrono::Local::now().to_rfc3339())
+            "ts" => FnValue(move |_ : &Record| {
+                time::OffsetDateTime::now_local()
+                    .unwrap_or_else(|_| time::OffsetDateTime::now_utc())
+                    .format(&time::format_description::well_known::Rfc3339)
+                    .ok()
             }),
             "level" => FnValue(move |rinfo : &Record| {
                 rinfo.level().as_short_str()


### PR DESCRIPTION
`cargo audit` flags this crate due to the `chrono` dependency flagging RUSTSEC-2020-0159.