### PR TITLE
Use UTC timezone for `ts` consistently

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,8 +332,7 @@ where
     pub fn add_default_keys(self) -> Self {
         self.add_key_value(o!(
             "ts" => FnValue(move |_ : &Record| {
-                time::OffsetDateTime::now_local()
-                    .unwrap_or_else(|_| time::OffsetDateTime::now_utc())
+                    time::OffsetDateTime::now_utc()
                     .format(&time::format_description::well_known::Rfc3339)
                     .ok()
             }),


### PR DESCRIPTION
Previously, slog would try to use the local timezone and fallback to UTC
in multi-threaded programs. The check for `is_single_threaded` takes an
non-negligible amount of time when there's lots of logging. This uses
UTC unconditionally instead, which both makes the format consistent across
programs and also speeds up logging slightly.

Fixes https://github.com/slog-rs/slog/issues/308.