### PR TITLE
Release 2.6.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ slog = { version = "2.1.1" }
 serde_json = "1"
 serde = "1"
 erased-serde = {version = "0.3", optional = true }
-time = { version = "0.3.6", features = ["formatting", "local-offset"] }
+time = { version = "0.3.6", features = ["formatting"] }
 
 [dev-dependencies]
 slog-async = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-json"
-version = "2.6.0"
+version = "2.6.1"
 edition = "2018"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>"]
 description = "JSON drain for slog-rs"


### PR DESCRIPTION
Bump version to 2.6.1

UTC by default (PR #30) is an important enough improvement/fix
that it warrants an immediate patch release.
    
This should not break any code because RFC 3339 requries
an explicit timezone for non-UTC times, and switching the timezone
should not break any conformant parser.

I also dropped the time/nested-values feature
because it is no longer needed.
