### PR TITLE
Implement the Drain::flush method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+* Implement `Drain::flush` method added in [slog-rs/slog#349]
+
+[slog-rs/slog#349]: https://github.com/slog-rs/slog/pull/349
 
 ## 2.6.0 - 2022-02-20
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,14 +25,14 @@ dynamic-keys = ["slog/dynamic-keys"]
 default = []
 
 [dependencies]
-slog = { version = "2.1.1" }
+slog = { git = "https://github.com/Techcable/slog.git", branch = "feature/simple-flush-method" }
 serde_json = "1"
 serde = "1"
 erased-serde = {version = "0.3", optional = true }
 time = { version = "0.3.6", features = ["formatting"] }
 
 [dev-dependencies]
-slog-async = "2"
+slog-async = { git = "https://github.com/Techcable/slog-async.git", branch = "feature/impl-simple-flush" }
 
 [package.metadata.docs.rs]
 features = ["nested-values", "dynamic-keys"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,6 +254,11 @@ where
         }
         Ok(())
     }
+
+    fn flush(&self) -> Result<(), slog::FlushError> {
+        let mut io = self.io.borrow_mut();
+        io.flush().map_err(slog::FlushError::from)
+    }
 }
 
 // }}}


### PR DESCRIPTION
Pinned to the branch used in slog-rs/slog#349, so that must be accepted first.

The 'pretty' example is also pinned to slog-rs/async#39. Otherwise compilation breaks.
