### PR TITLE
Upgrade to slog v2.8, Improve CI, and bump version to v2.7.0

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,8 +1,3 @@
-# This is the clippy workflow, seperate from the main 'Rust' workflow
-#
-# This will fail if clippy fails (if we encounter any of its "correctness" lints)
-#
-# Clippy warnings won't fail the build. They may or may not turn into Github warnings.
 on: [push, pull_request]
 name: Clippy
 
@@ -18,19 +13,31 @@ jobs:
   clippy:
     # Only run on PRs if the source branch is on someone else's repo
     if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}
+
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         rust:
+          # in hardcoded versions, warnings will fail the build
+          - 1.90
+          # in auto-updated versions, warnings will not fail the build
           - stable
+          - nightly
+
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
-          components: clippy
-      - shell: bash
+          components: clippy 
+      - uses: Swatinem/rust-cache@v2
+        if: ${{ matrix.rust != 'nightly' }}
+      - name: Clippy
         run: |
-          cargo clippy
+          cargo clippy --all --all-targets --verbose --all-features -- -D warnings
+        # When using hardcoded/pinned versions, warnings are forbidden.
+        #
+        # On automatically updated versions of rust (both stable & nightly) we allow clippy to fail.
+        # This is because automatic updates can introduce new lints or change existing lints.
+        continue-on-error: ${{ !contains(matrix.rust, '1.') }}

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -14,17 +14,10 @@ jobs:
     # Only run on PRs if the source branch is on someone else's repo
     if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - stable
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
           components: rustfmt
       - shell: bash
         run: |

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,23 @@
+# Checks spelling with typos
+# This has very few false positives, only checking for known misspellings (similar to codespell).
+# This action is based on https://github.com/crate-ci/typos/blob/master/docs/github-action.md
+name: Check Spelling
+on: [push, pull_request]
+
+env:
+  CLICOLOR: 1
+
+permissions:
+  contents: read
+
+jobs:
+  typos:
+    # Only run on PRs if the source branch is on someone else's repo
+    if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}
+
+    name: Check spelling with typos
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run typos (pinned version)
+      uses: crate-ci/typos@v1.35.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           # Minimum Supported Rust Version
           #
           # This is hardcoded and needs to be in sync with Cargo.toml and the README
-          - 1.53
+          - 1.61
 
           # Intermediate Releases (between MSRV and latest stable)
           # Be careful not to add these needlessly; they hold up CI

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,10 +62,13 @@ jobs:
           # Helpful for Rust versions that use old index
           cache-on-failure: true
       # Pin a time version with a compatible MSRV
-      - name: Pin time version
+      - name: Pin dependency versions for MSRV
         if: ${{ matrix.rust != 'nightly' && matrix.rust != 'stable' }}
         run: |
           cargo update --package time --precise 0.3.16
+          cargo update --package thread_local --precise 1.1.8
+          cargo update --package libc --precise 0.2.163
+          cargo update --package once_cell --precise 1.20.2
       - name: Check
         run: |
           cargo check --all-targets --verbose --no-default-features --features "${{ matrix.features }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,14 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - uses: Swatinem/rust-cache@v2
         if: ${{ matrix.rust != 'nightly' }} # ineffective due to version key
+        with:
+          # Helpful for Rust versions that use old index
+          cache-on-failure: true
+      # Pin a time version with a compatible MSRV
+      - name: Pin time version
+        if: ${{ matrix.rust != 'nightly' && matrix.rust != 'stable' }}
+        run: |
+          cargo update --package time --precise 0.3.16
       - name: Check
         run: |
           cargo check --all-targets --verbose --no-default-features --features "${{ matrix.features }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 # We use `actions-rs` for most of our actions
 #
-# This file is for the main tests. clippy & rustfmt are seperate workflows
-#
-# It is mostly copied from slog-rs/slog
+# This file is for the main tests. clippy & rustfmt are separate workflows
 on: [push, pull_request]
 name: Cargo Test
 
@@ -28,24 +26,71 @@ jobs:
     strategy:
       fail-fast: false # Even if one job fails we still want to see the other ones
       matrix:
-        # 1.53 is MSRV. Keep in sync with Cargo.toml
-        rust: [1.53, stable, nightly]
-        # NOTE: Features to test must be specified manually. They are applied to all versions seperately.
+        rust:
+          # Minimum Supported Rust Version
+          #
+          # This is hardcoded and needs to be in sync with Cargo.toml and the README
+          - 1.53
+
+          # Intermediate Releases (between MSRV and latest stable)
+          # Be careful not to add these needlessly; they hold up CI
+          # <nothing currently>
+
+          # The most recent version of stable rust (automatically updated)
+          - stable
+          - nightly
+        # NOTE: Features to test must be specified manually. They are applied to all versions separately.
         #
-        # This has the advantage of being more flexibile and thorough
-        # This has the disadvantage of being more vebrose
+        # This has the advantage of being more flexible and thorough
+        # This has the disadvantage of being more verbose
         #
-        # Specific feature combos can be overriden per-version with 'include' and 'exclude'
-        features: ["", "nested-values", "dynamic-keys", "nested-values dynamic-keys"]
+        # Specific feature combos can be overridden per-version with 'include' and 'ecclude'
+        features:
+          - ""
+          - "nested-values"
+          - "dynamic-keys"
+          - "nested-values dynamic-keys"
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
-      # NOTE: We only run `cargo test`. No need for a seperate `cargo check`
-      - name: Test
+      - uses: Swatinem/rust-cache@v2
+        if: ${{ matrix.rust != 'nightly' }} # ineffective due to version key
+      - name: Check
         run: |
-          cargo test --verbose --features "${{ matrix.features }}"
+          cargo check --all-targets --verbose --no-default-features --features "${{ matrix.features }}"
+        # A failing `cargo check` always fails the build
+        continue-on-error: false
+      - name: Test
+        # NOTE: Running --all-targets does not include doc tests
+        run: |
+          cargo test --all --verbose --no-default-features --features "${{ matrix.features }}"
 
+        # We require tests to succeed on all the feature combinations.
+        #
+        # However, we can grant special exceptions for the Minimum Supported Rust Version
+        # if there is a really good reason (like a dependency that requires a newer version).
+        continue-on-error: false
+      - name: rustdoc
+        # Restrict to working on nightly/stable (old versions might have undefined types)
+        if: ${{ matrix.rust == 'nightly' || matrix.rust == 'stable' }}
+        env:
+          RUSTDOCFLAGS: -Dwarnings
+        run: |
+          cargo doc --no-deps --all --verbose --no-default-features --features "${{ matrix.features }}"
+  # Runs the same build that docs.rs does. See https://github.com/dtolnay/cargo-docs-rs
+  docsrs:
+    # Only run on PRs if the source branch is on someone else's repo
+    if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}
+
+    name: docs.rs
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -Dwarnings
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/install@cargo-docs-rs
+      - run: cargo docs-rs

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,17 @@
+[default]
+extend-ignore-re = [
+    # support spellchecker directives (ideally this would be builtin)
+    "(?Rm)^.*(#|//)\\s*spellchecker:ignore$",
+    "(?s)(#|//)\\s*spellchecker:off.*?\\n\\s*(#|//)\\s*spellchecker:on",
+]
+
+[files]
+ignore-hidden = false
+extend-exclude = [
+    ".git", # needed because we set 'ignore-hidden'
+]
+
+[default.extend-identifiers]
+# the 'short' identifier for error
+erro = "erro"
+ERRO = "ERRO"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Upgrade to [slog v2.8.0].
   * Enable `nested-values` feature by default
   * Increase MSRV to 1.61 (same as slog)
+* Switch from `serde` to `serde_core`. Should reduce compile times.
 
 ### Added
 * Implement `Drain::flush` (new in [slog v2.8.0])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## 2.7.0 - 2025-10-05
+
 ### Changed
 * Upgrade to [slog v2.8.0].
   * Enable `nested-values` feature by default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+* Upgrade to [slog v2.8.0].
+  * Enable `nested-values` feature by default
+  * Increase MSRV to 1.61 (same as slog)
+
+### Added
+* Implement `Drain::flush` (new in [slog v2.8.0])
+
+[slog v2.8.0]: https://github.com/slog-rs/slog/releases/v2.8.0
 
 ## 2.6.0 - 2022-02-20
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-json"
-version = "2.6.1"
+version = "2.7.0"
 edition = "2018"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>"]
 description = "JSON drain for slog-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ dynamic-keys = ["slog/dynamic-keys"]
 [dependencies]
 slog = "2.8"
 serde_json = "1"
-serde = "1"
+serde = { package = "serde_core", version = "1" }
 erased-serde = { version = "0.4", optional = true }
 time = { version = "0.3.6", features = ["formatting"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,24 +15,23 @@ readme = "README.md"
 # Please do not bump this unnecessarily.
 # Changing this should bump the minor version for semver (2.x for semver).
 #
-# The first version of Cargo that supports this field was in Rust 1.56.0.
-# In older releases, the field will be ignored, and Cargo will display a warning.
-rust-version = "1.53"
+# This currently matches the MSRV of slog
+rust-version = "1.61"
 
 [features]
-nested-values = ["erased-serde", "slog/nested-values"]
+default = ["nested-values"]
+nested-values = ["dep:erased-serde", "slog/nested-values"]
 dynamic-keys = ["slog/dynamic-keys"]
-default = []
 
 [dependencies]
-slog = { version = "2.1.1" }
+slog = "2.8"
 serde_json = "1"
 serde = "1"
-erased-serde = {version = "0.3", optional = true }
+erased-serde = { version = "0.4", optional = true }
 time = { version = "0.3.6", features = ["formatting"] }
 
 [dev-dependencies]
 slog-async = "2"
 
 [package.metadata.docs.rs]
-features = ["nested-values", "dynamic-keys"]
+features = ["dynamic-keys"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,6 +251,11 @@ where
         }
         Ok(())
     }
+
+    fn flush(&self) -> Result<(), slog::FlushError> {
+        let mut io = self.io.borrow_mut();
+        io.flush().map_err(slog::FlushError::from)
+    }
 }
 
 // }}}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// {{{ Crate docs
+//! {{{ Crate docs
 //! JSON `Drain` for `slog-rs`
 //!
 //! ```
@@ -23,7 +23,6 @@
 extern crate slog;
 
 use serde::ser::SerializeMap;
-use serde::serde_if_integer128;
 use slog::Key;
 use slog::Record;
 use slog::{FnValue, PushFnValue};
@@ -132,13 +131,11 @@ where
     fn emit_f64(&mut self, key: Key, val: f64) -> slog::Result {
         impl_m!(self, key, &val)
     }
-    serde_if_integer128! {
-        fn emit_u128(&mut self, key: Key, val: u128) -> slog::Result {
-            impl_m!(self, key, &val)
-        }
-        fn emit_i128(&mut self, key: Key, val: i128) -> slog::Result {
-            impl_m!(self, key, &val)
-        }
+    fn emit_u128(&mut self, key: Key, val: u128) -> slog::Result {
+        impl_m!(self, key, &val)
+    }
+    fn emit_i128(&mut self, key: Key, val: i128) -> slog::Result {
+        impl_m!(self, key, &val)
     }
     fn emit_str(&mut self, key: Key, val: &str) -> slog::Result {
         impl_m!(self, key, &val)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,7 @@ where
     }
 
     /// Build custom `Json` `Drain`
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::new_ret_no_self))]
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(io: W) -> JsonBuilder<W> {
         JsonBuilder::new(io)
     }


### PR DESCRIPTION
Improves the CI, implement `Drain::flush`, and enables the `nested-values` feature by default.

This also bumps the minor version from 2.6 to 2.7. I would normally do this in a separate PR/commit to master, but I don't have admin permissions on this repo.